### PR TITLE
Opt every group into allowing photo uploads

### DIFF
--- a/app/controllers/expert/groups_controller.rb
+++ b/app/controllers/expert/groups_controller.rb
@@ -7,7 +7,7 @@
 class Expert::GroupsController < ApplicationController
   layout 'expert'
   before_filter :signin_required
-  
+
 
   def index
     @my_groups = current_user.group_memberships
@@ -194,10 +194,6 @@ class Expert::GroupsController < ApplicationController
 
       if @group.widget_public_option_changed?
         change_hash[:public_option] = {:old => @group.widget_public_option_was.to_s, :new => @group.widget_public_option.to_s}
-      end
-
-      if @group.widget_upload_capable_changed?
-        change_hash[:upload_capable] = {:old => @group.widget_upload_capable_was.to_s, :new => @group.widget_upload_capable.to_s}
       end
 
       if @group.widget_show_title_changed?

--- a/app/views/expert/groups/widget.html.erb
+++ b/app/views/expert/groups/widget.html.erb
@@ -28,13 +28,6 @@
     </p>
 
 	<p>
-        <label>
-          <%= f.check_box 'widget_upload_capable' %>  Enable photo upload option
-        </label>
-    </p>
-
-
-	<p>
       <label>
         <%= f.check_box 'widget_show_title' %>  Display title field on first generation widgets
 		    <span>(This preference only applies to the first generation widget, which is being phased out. The title field is always displayed on the <%= link_to "Question form", ask_group_url(@group.id) %> and the current generation widget.)</span>

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -48,7 +48,6 @@
     </fieldset>
 
 
-  <% if @group.widget_upload_capable? %>
     <fieldset class="image-upload-wrapper">
         <label>Image (optional)</label>
         <p><em>You can upload .jpg .png or .gif.</em></p>
@@ -56,7 +55,6 @@
           <p class="image-upload"><%= image_form.file_field :attachment  %></p>
         <% end %>
     </fieldset>
-  <% end %>
 
   <% if @group.is_australian? %>
   <fieldset>

--- a/app/views/widget/bonnie_plants.html.erb
+++ b/app/views/widget/bonnie_plants.html.erb
@@ -109,7 +109,6 @@
         <% end %>
       </p>
 
-    <% if @group.widget_upload_capable? %>
       <div class="image-upload-wrapper">
       <label>Image (optional)</label>
       <p><em>You can upload .jpg .png or .gif.</em></p>
@@ -119,7 +118,6 @@
           </p>
       <% end %>
     </div>
-    <% end %>
 
       <br />
 

--- a/app/views/widget/index.html.erb
+++ b/app/views/widget/index.html.erb
@@ -93,7 +93,6 @@
           <% end %>
         </p>
 
-    <% if @group.widget_upload_capable? %>
       <div class="image-upload-wrapper">
       <label>Image (optional)</label>
       <p><em>You can upload .jpg .png or .gif.</em></p>
@@ -104,7 +103,6 @@
           </p>
       <% end %>
     </div>
-    <% end %>
 
     <br />
 

--- a/app/views/widget/js_widget.html.erb
+++ b/app/views/widget/js_widget.html.erb
@@ -70,7 +70,6 @@
           <% end %>
         </p>
 
-    <% if @group.widget_upload_capable? %>
       <div class="image-upload-wrapper">
       <label>Image (optional)</label>
       <p><em>You can upload .jpg .png or .gif.</em></p>
@@ -81,7 +80,6 @@
           </p>
       <% end %>
     </div>
-    <% end %>
 
     <%- if !current_user or !current_user.email.present? -%>
     <p>

--- a/db/migrate/20180601154738_drop_upload_flag.rb
+++ b/db/migrate/20180601154738_drop_upload_flag.rb
@@ -1,0 +1,5 @@
+class DropUploadFlag < ActiveRecord::Migration
+  def up
+    remove_column(:groups, 'widget_upload_capable')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20180522183758) do
+ActiveRecord::Schema.define(:version => 20180601154738) do
 
   create_table "assets", :force => true do |t|
     t.string   "type"
@@ -216,7 +216,6 @@ ActiveRecord::Schema.define(:version => 20180522183758) do
     t.integer  "created_by",                                      :null => false
     t.boolean  "is_test",                      :default => false
     t.string   "widget_fingerprint"
-    t.boolean  "widget_upload_capable",        :default => false
     t.boolean  "unused_widget_show_location",  :default => false
     t.boolean  "widget_show_title",            :default => false
     t.boolean  "widget_enable_tags",           :default => false


### PR DESCRIPTION
The opt-in dates back to June of 2010, and until now has never been re-considered.  The UX was a little frustrating to folks - because the group form also honored the widget setting - but the question edit didn't - and submitters could actually come back and edit their question and add photos.